### PR TITLE
Adds Actions Permissions Monitor to blocklist job

### DIFF
--- a/.github/workflows/blocklist.yml
+++ b/.github/workflows/blocklist.yml
@@ -17,6 +17,9 @@ jobs:
         os:
           - ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor

This will help set the right permissions for #24